### PR TITLE
Allow rails >= 4 as valid dependency

### DIFF
--- a/protokoll.gemspec
+++ b/protokoll.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency("rails", "~> 4.0", "> 4.0")
+  s.add_dependency("rails", ">= 4.0")
 
   s.add_development_dependency "sqlite3", '~> 1'
 end


### PR DESCRIPTION
I think this change was unintentionally broken.
